### PR TITLE
Product Of Array Except Self (in C)

### DIFF
--- a/Algorithms/Dynamic Problems/ProductOfArrayExceptSelf.c
+++ b/Algorithms/Dynamic Problems/ProductOfArrayExceptSelf.c
@@ -1,0 +1,56 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int* ProductOfArrayExceptSelf(int* a, int arr_count);
+
+int main()
+{
+    int arr_size,i;
+    printf("Number of elements in an array: ");
+    scanf("%d",&arr_size);
+    int* arr = malloc(arr_size*sizeof(int));
+
+    printf("Enter the elements: ");
+
+    for(i = 0; i < arr_size; i++)
+        scanf("%d",&arr[i]);
+
+    int* result = ProductOfArrayExceptSelf(arr,arr_size);
+
+    for(i = 0; i < arr_size; i++)
+        printf("%d ",result[i]);
+
+    return 0;
+}
+
+int* ProductOfArrayExceptSelf(int* arr, int arr_count)
+{
+    int temp,i,product=1;
+    int* right_transversal = malloc(arr_count*sizeof(int));
+    int* left_transversal = malloc(arr_count*sizeof(int));
+    int* result = malloc(arr_count*sizeof(int));
+
+    for(i=0;i<arr_count;i++)
+    {
+        temp = arr[i];
+        left_transversal[i] = product;
+        product *= temp;
+    }
+    product = 1;
+    for(i=arr_count-1; i >= 0;i--)
+    {
+        temp = arr[i];
+        right_transversal[i] = product;
+        product *= temp;
+    }
+
+    for(i=0;i<arr_count;i++)
+        result[i] = right_transversal[i] * left_transversal[i];
+
+    return result;
+}
+
+
+/* Algorithm that runs in O(n) time and without using the division operation.
+Input: nums = [1,2,3,4]
+Output: [24,12,8,6] */

--- a/Leetcode/maximum rectangular area in histogram.cpp
+++ b/Leetcode/maximum rectangular area in histogram.cpp
@@ -1,3 +1,12 @@
+/*Test-case-1:
+Input: heights = [2,1,5,6,2,3]
+Output: 10
+Test-case-2:
+Input: heights = [2,4]
+Output: 4
+*/
+
+
 #include<bits/stdc++.h>
 using namespace std;
 class Solution {


### PR DESCRIPTION
# Description

I have provided the code for the below question in C language in the Dynamic Problem Folder.
Problem Statement: Given an integer array nums, return an array answer such that answer[i] is equal to the product of all the elements of nums except nums[i].

Fixes #1306

## Type of change

_Please delete options that are not relevant._
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines(Clean Code) of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests/screenshots(if any) that prove my fix is effective or that my feature works
